### PR TITLE
Changed comments on quantifiers with fixed length

### DIFF
--- a/lib/regex-to-railroad.coffee
+++ b/lib/regex-to-railroad.coffee
@@ -50,17 +50,23 @@ rx2rr = (node, options) ->
           if max is 1
             Optional(body)
           else
-            if max != Infinity
+            if max == 0
+              ZeroOrMore(body, Comment("#{max} times"))
+            else if max != Infinity
               ZeroOrMore(body, Comment("0 to #{max} times"))
             else
               ZeroOrMore(body)
         when 1
-          if max != Infinity
+          if max == 1
+            OneOrMore(body, Comment("once"))
+          else if max != Infinity
             OneOrMore(body, Comment("1 to #{max} times"))
           else
             OneOrMore(body)
         else
-          if max != Infinity
+          if max == min
+            OneOrMore(body, Comment("#{max} times"))
+          else if max != Infinity
             OneOrMore(body, Comment("#{min} to #{max} times"))
           else
             OneOrMore(body, Comment("at least #{min} times"))

--- a/src/regex-parser.coffee
+++ b/src/regex-parser.coffee
@@ -16,6 +16,11 @@ grammar =
           {min, max} = quantifier
           if min == 0
             ZeroOrMore(0, regex, Comment("#{max} times"))
+          else if min == max
+            if min == 1
+              OneOrMore(0, regex, Comment("once"))
+            else
+              OneOrMore(0, regex, Comment("#{max} times"))
           else
             OneOrMore(0, regex, Comment("#{min} to #{max} times"))
         o "(?= Regex )", (regex) -> Sequence(0, regex, Comment("Lookahead")) # maybe we pass some extra classed for getting this boxed


### PR DESCRIPTION
"0 to 0 times" -> "0 times"
"1 to 1 times" -> "once"
"x to x times" -> "x times"
