### PR TITLE
Fix for #80

### DIFF
--- a/lib/regex-railroad-diagram.coffee
+++ b/lib/regex-railroad-diagram.coffee
@@ -54,7 +54,7 @@ module.exports =
   bufferRangeForScope: (editor, scope, position=null) ->
     unless issue58
       if position?
-        result = editor.displayBuffer.bufferRangeForScopeAtPosition(scope, position)
+        result = editor.bufferRangeForScopeAtPosition(scope, position)
       else
         result = editor.bufferRangeForScopeAtCursor(scope)
       return result
@@ -80,7 +80,7 @@ module.exports =
     if startTabs
       position.column = position.column - startTabs + startTabs*tabLength
 
-    result = editor.displayBuffer.bufferRangeForScopeAtPosition(scope, position)
+    result = editor.bufferRangeForScopeAtPosition(scope, position)
     return result unless result
 
     # this is usually only one row, but if at some point the range would span

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/klorenz/atom-regex-railroad-diagrams",
   "license": "MIT",
   "engines": {
-    "atom": ">0.200.0"
+    "atom": ">=1.13.0"
   },
   "dependencies": {
     "regexp": "git+https://github.com/klorenz/regexp.git#v1.4.0",


### PR DESCRIPTION
remove 'displayBuffer' from regex-railroad-diagram.coffee.
Fix for #80 
This will eliminate a Deprecated call.