### PR TITLE
Improve light theme readability

### DIFF
--- a/styles/regex-railroad-diagram.less
+++ b/styles/regex-railroad-diagram.less
@@ -48,7 +48,7 @@ regex-railroad-diagram {
       // for fill
       @l: 120;
       @d:  80;
-      @a: 0.2;
+      @a: 0.5;
 
       // for text
       @tl: 220;


### PR DESCRIPTION
This fixes https://github.com/klorenz/atom-regex-railroad-diagrams/issues/72

This tiny change improves the readability greatly.

Before:
![image](https://cloud.githubusercontent.com/assets/1003739/22395678/495ca502-e599-11e6-8064-5e6eaa1f1a50.png)

After:
![image](https://cloud.githubusercontent.com/assets/1003739/22395684/66f7e22a-e599-11e6-8023-19e8908f2f9c.png)
