### PR TITLE
:bug: fix #86

### DIFF
--- a/lib/railroad-diagram-element.coffee
+++ b/lib/railroad-diagram-element.coffee
@@ -45,7 +45,7 @@ class RailroadDiagramElement extends HTMLElement
     @regexGrammars = {}
     for grammar in atom.grammars.getGrammars()
       console.log "grammar", grammar.name
-      if grammar.name.match /.*reg.*ex/i
+      if grammar.name?.match /.*reg.*ex/i
         displayName = grammar.name
         @textEditor.setGrammar(grammar)
         #if m = grammar.name.match /\((.*)\)/


### PR DESCRIPTION
Some grammars don't have a name property set like `https://github.com/reasonml-editor/language-reason/blob/master/grammars/reason-hover-type.json`. This throws `Cannot read property 'match' of undefined` at activation time, thus rendering the whole plugin unusable.

Checking if the name prop exists before accessing it prevents that.